### PR TITLE
fix: incorrect renown levels for crafting knowledge rewards

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -9,6 +9,14 @@ app.api = {}	-- Create a table to use for our "API"
 ProfessionShoppingList = app.api	-- Create a namespace for our "API"
 local api = app.api	-- Our "API" prefix
 
+
+local FACTION_ID = {
+  MARUUK_CENTAUR = 2503,
+  DRAGONSCALE_EXPEDITION = 2507,
+  VALDRAKKEN_ACCORD = 2510,
+  ISKAARA_TUSKARR = 2511
+}
+
 -- Blizzard API Events
 local event = CreateFrame("Frame")
 event:RegisterEvent("ADDON_LOADED")
@@ -3298,10 +3306,21 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 					renownInfo = {}
 					local title1 = GetFactionInfoByID(renown[1].factionID)
 					local title2 = GetFactionInfoByID(renown[2].factionID)
-					renownInfo[1] = { locked = C_MajorFactions.GetRenownLevels(renown[1].factionID)[12].locked, questID = renown[1].questID14, title = title1, level = 12 }
+					renownInfo[1] = { locked = C_MajorFactions.GetRenownLevels(renown[1].factionID)[14].locked, questID = renown[1].questID14, title = title1, level = 14 }
 					renownInfo[2] = { locked = C_MajorFactions.GetRenownLevels(renown[1].factionID)[24].locked, questID = renown[1].questID24, title = title1, level = 24 }
-					renownInfo[3] = { locked = C_MajorFactions.GetRenownLevels(renown[2].factionID)[12].locked, questID = renown[2].questID14, title = title2, level = 12 }
+					renownInfo[3] = { locked = C_MajorFactions.GetRenownLevels(renown[2].factionID)[14].locked, questID = renown[2].questID14, title = title2, level = 14 }
 					renownInfo[4] = { locked = C_MajorFactions.GetRenownLevels(renown[2].factionID)[24].locked, questID = renown[2].questID24, title = title2, level = 24 }
+
+					-- This is the weird Dragonscale 14 and 23 renown level rewards.
+					-- Possibly a bug or an oversight by warcraft devs.
+					if renown[1].factionID == FACTION_ID.DRAGONSCALE_EXPEDITION then
+						renownInfo[2] = {
+								locked = C_MajorFactions.GetRenownLevels(renown[1].factionID)[23].locked,
+								questID = renown[1].questID23,
+								title = title1,
+								level = 23
+						}
+					end
 
 					renownCount = 0
 					for key, info in ipairs (renownInfo) do
@@ -3595,8 +3614,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75846, itemID = 205428}
 				books[6] = {questID = 75849, itemID = 205439}
 				renown = {}
-				renown[1] = {factionID = 2503, questID14 = 72312, questID24 = 72315}
-				renown[2] = {factionID = 2510, questID14 = 72329, questID24 = 70909}
+				renown[1] = {factionID = FACTION_ID.MARUUK_CENTAUR, questID14 = 72312, questID24 = 72315}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 72329, questID24 = 70909}
 				dmf = 29508
 			end
 
@@ -3639,8 +3658,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75840, itemID = 205426}
 				books[6] = {questID = 75855, itemID = 205437}
 				renown = {}
-				renown[1] = {factionID = 2503, questID14 = 72296, questID24 = 72297}
-				renown[2] = {factionID = 2511, questID14 = 72321, questID24 = 72326}
+				renown[1] = {factionID = FACTION_ID.MARUUK_CENTAUR, questID14 = 72296, questID24 = 72297}
+				renown[2] = {factionID = FACTION_ID.ISKAARA_TUSKARR, questID14 = 72321, questID24 = 72326}
 				dmf = 29517
 			end
 
@@ -3683,8 +3702,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75847, itemID = 205429}
 				books[6] = {questID = 75848, itemID = 205440}
 				renown = {}
-				renown[1] = {factionID = 2503, questID14 = 72311, questID24 = 72314}
-				renown[2] = {factionID = 2510, questID14 = 70892, questID24 = 70889}
+				renown[1] = {factionID = FACTION_ID.MARUUK_CENTAUR, questID14 = 72311, questID24 = 72314}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 70892, questID24 = 70889}
 				dmf = 29506
 			end
 
@@ -3713,8 +3732,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75843, itemID = 205434}
 				books[6] = {questID = 75852, itemID = 205445}
 				renown = {}
-				renown[1] = {factionID = 2503, questID14 = 72313, questID24 = 72316}
-				renown[2] = {factionID = 2511, questID14 = 72319, questID24 = 72324}
+				renown[1] = {factionID = FACTION_ID.MARUUK_CENTAUR, questID14 = 72313, questID24 = 72316}
+				renown[2] = {factionID = FACTION_ID.ISKAARA_TUSKARR, questID14 = 72319, questID24 = 72324}
 				dmf = 29514
 			end
 
@@ -3743,8 +3762,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75839, itemID = 205432}
 				books[6] = {questID = 75856, itemID = 205443}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72302, questID24 = 72308}
-				renown[2] = {factionID = 2510, questID14 = 72332, questID24 = 72335}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72302, questID23 = 72308}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 72332, questID24 = 72335}
 				dmf = 29518
 			end
 
@@ -3788,8 +3807,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75837, itemID = 205431}
 				books[6] = {questID = 75858, itemID = 205442}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72303, questID24 = 72309}
-				renown[2] = {factionID = 2510, questID14 = 72333, questID24 = 72336}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72303, questID23 = 72309}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 72333, questID24 = 72336}
 				dmf = 29520
 			end
 
@@ -3832,8 +3851,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75844, itemID = 205425}
 				books[6] = {questID = 75851, itemID = 205436}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72300, questID24 = 72305}
-				renown[2] = {factionID = 2510, questID14 = 72330, questID24 = 70902}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72300, questID23 = 72305}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 72330, questID24 = 70902}
 				dmf = 29511
 			end
 
@@ -3877,8 +3896,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75845, itemID = 205427}
 				books[6] = {questID = 75850, itemID = 205438}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72299, questID24 = 72304}
-				renown[2] = {factionID = 2511, questID14 = 72318, questID24 = 72323}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72299, questID23 = 72304}
+				renown[2] = {factionID = FACTION_ID.ISKAARA_TUSKARR, questID14 = 72318, questID24 = 72323}
 				dmf = 29510
 			end
 
@@ -3907,8 +3926,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75838, itemID = 205433}
 				books[6] = {questID = 75857, itemID = 205444}
 				renown = {}
-				renown[1] = {factionID = 2503, questID14 = 72310, questID24 = 72317}
-				renown[2] = {factionID = 2511, questID14 = 72322, questID24 = 72327}
+				renown[1] = {factionID = FACTION_ID.MARUUK_CENTAUR, questID14 = 72310, questID24 = 72317}
+				renown[2] = {factionID = FACTION_ID.ISKAARA_TUSKARR, questID14 = 72322, questID24 = 72327}
 				dmf = 29519
 			end
 
@@ -3952,8 +3971,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75841, itemID = 205424}
 				books[6] = {questID = 75854, itemID = 205435}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72301, questID24 = 72306}
-				renown[2] = {factionID = 2511, questID14 = 72320, questID24 = 72325}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72301, questID23 = 72306}
+				renown[2] = {factionID = FACTION_ID.ISKAARA_TUSKARR, questID14 = 72320, questID24 = 72325}
 				dmf = 29516
 			end
 
@@ -3997,8 +4016,8 @@ event:SetScript("OnEvent", function(self, event, arg1, arg2, ...)
 				books[5] = {questID = 75842, itemID = 205430}
 				books[6] = {questID = 75853, itemID = 205441}
 				renown = {}
-				renown[1] = {factionID = 2507, questID14 = 72294, questID24 = 72295}
-				renown[2] = {factionID = 2510, questID14 = 72331, questID24 = 72334}
+				renown[1] = {factionID = FACTION_ID.DRAGONSCALE_EXPEDITION, questID14 = 72294, questID23 = 72295}
+				renown[2] = {factionID = FACTION_ID.VALDRAKKEN_ACCORD, questID14 = 72331, questID24 = 72334}
 				dmf = 29515
 			end
 


### PR DESCRIPTION
![changes_enchanting_dragonscale_expedition_lvl_23](https://github.com/Sluimerstand/ProfessionShoppingList/assets/32260816/7c5152e9-9eee-42a9-92f1-fca6e471005e)


Fixes #120 