### PR TITLE
Add Track All button to crafting orders

### DIFF
--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -123,6 +123,7 @@ local L = app.locales
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -123,6 +123,7 @@ L.BUTTON_LIGHTFORGE =                  app.IconLMB .. ": Cast"
 
 -- Track new mogs
 L.BUTTON_TRACKNEW =                    "Track New Mogs"
+L.BUTTON_TRACKALL =                    "Track All"
 L.CURRENT_SETTING =                    "Current setting:"
 L.MODE_APPEARANCES =                   "new appearances"
 L.MODE_SOURCES =                       "new appearances and sources"

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -123,6 +123,7 @@ L.WINDOW_BUTTON_SETTINGS =				"Abrir opciones"
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/esMX.lua
+++ b/locales/esMX.lua
@@ -123,6 +123,7 @@ L.WINDOW_BUTTON_SETTINGS =				"Abrir opciones"
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -123,6 +123,7 @@ L.BUTTON_LIGHTFORGE =					app.IconLMB .. " : lancer"
 
 -- Track new mogs
 L.BUTTON_TRACKNEW =						"Suivre les apparences inconnues"
+-- L.BUTTON_TRACKALL =						"Track All"
 L.CURRENT_SETTING =						"Paramètre actuel :"
 L.MODE_APPEARANCES =					"nouvelles apparences"
 L.MODE_SOURCES =						"nouvelles apparences et sources"

--- a/locales/itIT.lua
+++ b/locales/itIT.lua
@@ -123,6 +123,7 @@ local L = app.locales
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/koKR.lua
+++ b/locales/koKR.lua
@@ -123,6 +123,7 @@ local L = app.locales
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/ptBR.lua
+++ b/locales/ptBR.lua
@@ -123,6 +123,7 @@ local L = app.locales
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -123,6 +123,7 @@ L.BUTTON_LIGHTFORGE =					app.IconLMB .. ": Каст"
 
 -- Track new mogs
 L.BUTTON_TRACKNEW =						"Отслеживать новые образы"
+-- L.BUTTON_TRACKALL =						"Track All"
 L.CURRENT_SETTING =						"Текущая настройка:"
 L.MODE_APPEARANCES =					"новые внешние виды"
 L.MODE_SOURCES =						"новые внешние виды и источники"

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -123,6 +123,7 @@ L.FROM =								"来自"	-- 用于材料来源说明
 
 -- Track new mogs
 L.BUTTON_TRACKNEW =						"追踪新外观"
+-- L.BUTTON_TRACKALL =						"Track All"
 L.CURRENT_SETTING =						"当前设置："
 L.MODE_APPEARANCES =					"新外观"
 L.MODE_SOURCES =						"新外观及来源"

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -123,6 +123,7 @@ local L = app.locales
 
 -- Track new mogs
 -- L.BUTTON_TRACKNEW =						"Track New Mogs"
+-- L.BUTTON_TRACKALL =						"Track All"
 -- L.CURRENT_SETTING =						"Current setting:"
 -- L.MODE_APPEARANCES =					"new appearances"
 -- L.MODE_SOURCES =						"new appearances and sources"

--- a/modules/CraftingOrders.lua
+++ b/modules/CraftingOrders.lua
@@ -692,4 +692,36 @@ app.Event:Register("CRAFTINGORDERS_UPDATE_ORDER_COUNT", function(orderType, numO
 
 		ScrollUtil.AddInitializedFrameCallback(ProfessionsFrame.OrdersPage.BrowseFrame.OrderList.ScrollBox, OnFrameInitialized, nil, true)
 	end
+
+	-- Track All button
+	if not app.TrackAllOrdersButton then
+		app.TrackAllOrdersButton = app:MakeButton(ProfessionsFrame.OrdersPage.BrowseFrame, L.BUTTON_TRACKALL)
+		app.TrackAllOrdersButton:SetPoint("TOPRIGHT", ProfessionsFrame.OrdersPage.BrowseFrame, "TOPRIGHT", -25, -5)
+		app.TrackAllOrdersButton:SetScript("OnClick", function()
+			local dataProvider = ProfessionsFrame.OrdersPage.BrowseFrame.OrderList.ScrollBox:GetDataProvider()
+			if not dataProvider then return end
+
+			app.Flag.ChangingRecipes = true
+
+			dataProvider:ForEach(function(elementData)
+				if elementData and elementData.option and elementData.option.orderID and elementData.option.spellID then
+					local spellID = elementData.option.spellID
+					local orderID = elementData.option.orderID
+					local isRecraft = elementData.option.isRecraft
+					local key = "order:" .. orderID .. ":" .. spellID
+
+					if not ProfessionShoppingList_Data.Recipes[key] then
+						local recipeInfo = C_TradeSkillUI.GetRecipeInfo(spellID)
+						if recipeInfo and recipeInfo.learned then
+							api:TrackRecipe(spellID, 1, isRecraft, orderID)
+						end
+					end
+				end
+			end)
+
+			app.Flag.ChangingRecipes = false
+			app:ShowWindow()
+			app:UpdateAssets()
+		end)
+	end
 end)


### PR DESCRIPTION
To make it easier to add all the crafting orders in one go, I added a "Track All" button to the top right of the frame. It will automatically add all orders in the current open frame. It skips any unlearned recipes.

The reason for adding this feature is to avoid having to right click -> Track each individual item, when you just want to get your daily/weekly crafting in.